### PR TITLE
Allow processing multiple raw paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 OPENROUTER_MODEL_ID=openai/gpt-4.1
 OPENROUTER_API_KEY=<your-api-key>
-RAW_FILES_DIR=<path-to-your-raw-documents>
+# Multiple paths can be separated with ';'
+RAW_FILES_DIR=<path-to-your-raw-documents;another-path-if-needed>
 PROCESSED_FILES_DIR=<path-to-your-processed-documents>
 EXPORT_FILES_DIR=<path-to-your-export-directory>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ documentor <task> <processed_path> [--raw_path ...] [--excel_output_path ...] [-
   Extract metadata from new PDFs in a raw folder and copy them to the processed folder.  
   **Usage:**  
   ```bash
-  documentor extract_new <processed_path> --raw_path <raw_pdf_folder>
+  documentor extract_new <processed_path> --raw_path <raw_folder1;raw_folder2>
   ```
 
 - `rename_files`  


### PR DESCRIPTION
## Summary
- enable scanning multiple raw folders
- support semicolon-delimited paths via CLI and pipeline
- document multiple path support in README and `.env.example`

## Testing
- `python -m py_compile main.py`
- `python main.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68455edffc308332976c7408415196c4